### PR TITLE
change outstanding order links to use edit path

### DIFF
--- a/app/views/spree/admin/reports/outstanding.html.erb
+++ b/app/views/spree/admin/reports/outstanding.html.erb
@@ -8,7 +8,7 @@
   </tr>
   <% @orders.each do |order| %>
     <tr>
-      <td><%= link_to order.number, admin_order_path(order) %></td>
+      <td><%= link_to order.number, edit_admin_order_path(order) %></td>
       <td><%= l order.completed_at.to_date %></td>
       <td><%= order.outstanding_balance %></td>
     </tr>


### PR DESCRIPTION
The links to the orders listed in the outstanding orders report are broken, at least in 2.1.  The spree admin interface uses the edit path to link to orders in the order list.  I've changed the report's links to do the same.
